### PR TITLE
Switch to a new OpenUnion implementation.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.2.4.0 (Sep. 7, 2016)
+
+* Switch to another `Data.Open.Union` implementation which has constant-time injection/projection.
+
 # 0.2.3.0 (June 25, 2016)
 
 * Add GHC 8 support


### PR DESCRIPTION
> I ported Oleg Kiselyov's improved OpenUnion implementation here (source). The previous implementation is a nested Either and operations take linear time, this version restores constant time injection/projection.

(clone of https://gitlab.com/queertypes/freer/merge_requests/8)