### PR TITLE
Add benchmarks to compare `extensible-effects`

### DIFF
--- a/bench/Core.hs
+++ b/bench/Core.hs
@@ -181,12 +181,12 @@ main =
         bench "freer.ExcState"  $ whnf countDownExc 10000
       , bench "mtl.ExceptState" $ whnf countDownExcMTL 10000
       , bench "ee.ExcState"     $ whnf countDownExcEE 10000
-    ]{-},
+    ],
     bgroup "HTTP Simple DSL" [
         bench "freer" $ whnf (run . runHttp) prog
       , bench "free" $ whnf runFHttp prog'
 
       , bench "freerN"      $ whnf (run . runHttp . p) 1000
       , bench "freeN"       $ whnf (runFHttp . p')     1000
-    ]-}
+    ]
   ]

--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -179,11 +179,12 @@ benchmark core
   default-language:     Haskell2010
 
   build-depends:
-      base
-    , criterion
-    , free
-    , freer-effects
-    , mtl
+                base
+              , criterion
+              , free
+              , freer-effects
+              , mtl
+              , extensible-effects >= 1.11 && < 1.12
 
   ghc-options:          -Wall -O2
 


### PR DESCRIPTION
I've been on the `Eff` bandwagon for a while now, and have really enjoyed using `extensible-effects`. The project's momentum seems low, and it doesn't yet include the improvements from the `Freer` paper (and might never). I noticed yesterday that `freer` had been forked, and since it looks like you have commercial backing, this library will probably stay the best maintained and have the most resources devoted to it. So I'm throwing in my chips with you (I use EE a lot).

This PR adds benchmarks for comparing `extensible-effects` alongside `freer-effects` and `mtl`. Suffice to say, FE does quite a bit better than EE.

![benches](https://cloud.githubusercontent.com/assets/229679/23835541/552a04f2-0726-11e7-82e8-d6466c4000c4.png)

As a tangent, I prefer your API surrounding lifting Monads into `Eff`. It took me a while to figure out that `send` was the mechanic to do that, but I like that it avoids the whole `SetMember` ceremony that `extensible-effects` chose. However I don't enjoy that `runReader` and `runState` have their state argument passed second. It's very annoying for application:

```haskell
foo = run . runError $ runReader (runState (runWriter bar) s) env
```
as opposed to
```haskell
foo = run . runError . runReader env . runState s $ runWriter bar
```