### PR TITLE
Provides a better Fresh implementation for use with Coroutine

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
   helper function named `replyC`.
   [PR #25](https://github.com/IxpertaSolutions/freer-effects/pull/25)
   (**new**)
+* Introduced `Fresh` effect handlers `runFresh` and `evalFresh`. Function
+  `runFresh'` was deprecated in favour of `evalFresh`.
+  [PR #24](https://github.com/IxpertaSolutions/freer-effects/pull/24)
+  (**new, change**)
 
 ## [0.3.0.0] (March 06, 2017)
 

--- a/examples/src/Fresh.hs
+++ b/examples/src/Fresh.hs
@@ -10,13 +10,14 @@ import Control.Monad.Freer.Fresh (evalFresh, fresh)
 import Control.Monad.Freer.Trace (runTrace, trace)
 
 
+-- | Generate two fresh values.
+--
+-- >>> traceFresh
+-- Fresh 0
+-- Fresh 1
 traceFresh :: IO ()
 traceFresh = runTrace $ flip evalFresh 0 $ do
-  n <- fresh
-  trace $ "Fresh " <> show n
-  n' <- fresh
-  trace $ "Fresh " <> show n'
-{-
-Fresh 0
-Fresh 1
--}
+    n <- fresh
+    trace $ "Fresh " <> show n
+    n' <- fresh
+    trace $ "Fresh " <> show n'

--- a/examples/src/Fresh.hs
+++ b/examples/src/Fresh.hs
@@ -6,12 +6,12 @@ import Data.Monoid ((<>))
 import System.IO (IO)
 import Text.Show (show)
 
-import Control.Monad.Freer.Fresh (fresh, runFresh')
+import Control.Monad.Freer.Fresh (evalFresh, fresh)
 import Control.Monad.Freer.Trace (runTrace, trace)
 
 
 traceFresh :: IO ()
-traceFresh = runTrace $ flip runFresh' 0 $ do
+traceFresh = runTrace $ flip evalFresh 0 $ do
   n <- fresh
   trace $ "Fresh " <> show n
   n' <- fresh

--- a/src/Control/Monad/Freer/Fresh.hs
+++ b/src/Control/Monad/Freer/Fresh.hs
@@ -24,9 +24,9 @@ module Control.Monad.Freer.Fresh
     )
   where
 
-import Prelude (($!), (+), (<$>), (.), fst)
+import Prelude (($!), (+), (.), fst)
 
-import Control.Applicative (pure)
+import Control.Applicative (pure, (<$>))
 import Data.Int (Int)
 
 import Control.Monad.Freer.Internal (Eff, Member, handleRelayS, send)

--- a/src/Control/Monad/Freer/Fresh.hs
+++ b/src/Control/Monad/Freer/Fresh.hs
@@ -24,31 +24,30 @@ module Control.Monad.Freer.Fresh
     )
   where
 
-import Prelude (($!), (+), (.), fst)
+import Prelude (($!), (+))
 
-import Control.Applicative (pure, (<$>))
+import Control.Applicative (pure)
+import Data.Function ((.))
+import Data.Functor ((<$>))
 import Data.Int (Int)
+import Data.Tuple (fst)
 
 import Control.Monad.Freer.Internal (Eff, Member, handleRelayS, send)
 
 
---------------------------------------------------------------------------------
-                             -- Fresh --
---------------------------------------------------------------------------------
-
 -- | Fresh effect model.
 data Fresh a where
-  Fresh :: Fresh Int
+    Fresh :: Fresh Int
 
 -- | Request a fresh effect.
 fresh :: Member Fresh effs => Eff effs Int
 fresh = send Fresh
 
--- | Handler for 'Fresh' effects, with an 'Int' for a starting value. The return
--- value includes the next fresh value.
+-- | Handler for 'Fresh' effects, with an 'Int' for a starting value. The
+-- return value includes the next fresh value.
 runFresh :: Eff (Fresh ': effs) a -> Int -> Eff effs (a, Int)
 runFresh m s =
-  handleRelayS s (\_s a -> pure (a, _s)) (\s' Fresh k -> (k $! s' + 1) s') m
+    handleRelayS s (\s' a -> pure (a, s')) (\s' Fresh k -> (k $! s' + 1) s') m
 
 -- | Handler for 'Fresh' effects, with an 'Int' for a starting value. Discards
 -- the next fresh value.

--- a/src/Control/Monad/Freer/Fresh.hs
+++ b/src/Control/Monad/Freer/Fresh.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+
 -- |
 -- Module:       Control.Monad.Freer.Fresh
 -- Description:  Generation of fresh integers as an effect.
@@ -16,11 +17,13 @@
 -- implementing De Bruijn naming/scopes.
 --
 -- Using <http://okmij.org/ftp/Haskell/extensible/Eff1.hs> as a starting point.
+
 module Control.Monad.Freer.Fresh
     ( Fresh(..)
     , fresh
     , runFresh
     , evalFresh
+    , runFresh'
     )
   where
 
@@ -53,3 +56,10 @@ runFresh m s =
 -- the next fresh value.
 evalFresh :: Eff (Fresh ': effs) a -> Int -> Eff effs a
 evalFresh = ((fst <$>) .) . runFresh
+
+-- | Backward compatibility alias for 'evalFresh'.
+runFresh' :: Eff (Fresh ': effs) a -> Int -> Eff effs a
+runFresh' = evalFresh
+{-# DEPRECATED runFresh'
+    "Use `evalFresh` instead, this function will be removed in next release."
+  #-}

--- a/tests/Tests/Fresh.hs
+++ b/tests/Tests/Fresh.hs
@@ -11,13 +11,14 @@ import Data.Functor ((<$>))
 import Data.Int (Int)
 import Data.List (last)
 import Data.Ord ((>))
+import Data.Tuple (fst)
 
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@?=), testCase)
 import Test.Tasty.QuickCheck ((==>), testProperty)
 
 import Control.Monad.Freer (Eff, run)
-import Control.Monad.Freer.Fresh (fresh, runFresh')
+import Control.Monad.Freer.Fresh (fresh, runFresh)
 
 
 tests :: TestTree
@@ -29,7 +30,7 @@ tests = testGroup "Fresh tests"
     ]
 
 makeFresh :: Int -> Eff r Int
-makeFresh n = runFresh' (last <$> replicateM n fresh) 0
+makeFresh n = fst <$> runFresh (last <$> replicateM n fresh) 0
 
 testFresh :: Int -> Int
 testFresh = run . makeFresh


### PR DESCRIPTION
Just some changes to make `Fresh` easier to use in conjunction with `Coroutine`. If you can't get the latest `Fresh` value, you can't continue your coroutine.