### PR TITLE
Better coroutine

### DIFF
--- a/src/Control/Monad/Freer/Coroutine.hs
+++ b/src/Control/Monad/Freer/Coroutine.hs
@@ -16,20 +16,24 @@
 --
 -- Using <http://okmij.org/ftp/Haskell/extensible/Eff1.hs> as a starting point.
 module Control.Monad.Freer.Coroutine
-    ( Yield(..)
+    (
+    -- * Yield Control
+      Yield(..)
     , yield
+
+    -- * Handle Yield Effect
     , Status(..)
     , runC
-    , runC'
+    , interposeC
+    , replyC
     )
   where
 
-import Control.Monad (return)
+import Control.Applicative (pure)
 import Data.Function (($), (.))
 import Data.Functor (Functor)
 
-import Control.Monad.Freer.Internal (Arr, Eff, Member, handleRelay, send,
-                                     interpose)
+import Control.Monad.Freer.Internal (Eff, Member, handleRelay, interpose, send)
 
 
 -- | A type representing a yielding of control.
@@ -52,25 +56,28 @@ yield :: Member (Yield a b) effs => a -> (b -> c) -> Eff effs c
 yield x f = send (Yield x f)
 
 -- | Represents status of a coroutine.
-data Status effs a b x
-    = Done x
-    -- ^ Coroutine is done with a result value.
-    | Continue a (b -> Eff effs (Status effs a b x))
+data Status effs a b r
+    = Done r
+    -- ^ Coroutine is done with a result value of type @r@.
+    | Continue a (b -> Eff effs (Status effs a b r))
     -- ^ Reporting a value of the type @a@, and resuming with the value of type
     -- @b@, possibly ending with a value of type @x@.
 
 -- | Reply to a coroutine effect by returning the Continue constructor.
 replyC
   :: Yield a b c
-  -> Arr r c (Status r a b w)
-  -> Eff r (Status r a b w)
-replyC (Yield a k) arr = return $ Continue a (arr . k)
+  -> (c -> Eff effs (Status effs a b r))
+  -> Eff effs (Status effs a b r)
+replyC (Yield a k) arr = pure $ Continue a (arr . k)
 
 -- | Launch a coroutine and report its status.
-runC :: Eff (Yield a b ': effs) w -> Eff effs (Status effs a b w)
-runC = handleRelay (return . Done) replyC
+runC :: Eff (Yield a b ': effs) r -> Eff effs (Status effs a b r)
+runC = handleRelay (pure . Done) replyC
 
 -- | Launch a coroutine and report its status, without handling (removing)
--- `Yield` from the typelist. This is useful for reducing nested coroutines.
-runC' :: Member (Yield a b) r => Eff r w -> Eff r (Status r a b w)
-runC' = interpose (return . Done) replyC
+-- 'Yield' from the typelist. This is useful for reducing nested coroutines.
+interposeC
+    :: Member (Yield a b) effs
+    => Eff effs r
+    -> Eff effs (Status effs a b r)
+interposeC = interpose (pure . Done) replyC

--- a/tests/Tests/Coroutine.hs
+++ b/tests/Tests/Coroutine.hs
@@ -55,6 +55,6 @@ runTestCoroutine list = snd . run $ runState effTestCoroutine 0
 
     effTestCoroutine = runC testCoroutine >>= handleStatus list
       where
-        handleStatus _      Done            = pure ()
+        handleStatus _      (Done ())       = pure ()
         handleStatus (i:is) (Continue () k) = k i >>= handleStatus is
         handleStatus []     _               = pure ()


### PR DESCRIPTION
This provides `Coroutine` with a return value, which makes it more composable (and actually useful). It also provides `runC'` which does not strip the effect from the typelist, allowing more complicated branching schemes (like step-wise dueling coroutines).