### PR TITLE
Fixes endless loop when using `forever`.

### DIFF
--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -126,6 +126,7 @@ test-suite test
     , Tests.Reader
     , Tests.State
     , Tests.StateRW
+    , Tests.Loop
 
   default-language:     Haskell2010
 

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -136,7 +136,6 @@ instance Applicative (Eff effs) where
 
     Val f <*> Val x = Val $ f x
     Val f <*> E u q = E u (q |> (Val . f))
-    E u q <*> Val x = E u (q |> (Val . ($ x)))
     E u q <*> m     = E u (q |> (`fmap` m))
     {-# INLINE (<*>) #-}
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -145,7 +145,7 @@ testLoop :: IO Int
 testLoop = do
   ref <- newIORef 0
   tid <- forkIO $ runM $ loop ref
-  threadDelay $ 10^6 * 2
+  threadDelay $ 10^(6 :: Int) * 2
   killThread tid
   readIORef ref
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -2,22 +2,23 @@
 module Main where
 
 #if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
+import           Control.Applicative
 #endif
 
-import Control.Monad.Freer
+import           Control.Monad.Freer
 
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
 
-import Tests.Coroutine
-import Tests.Exception
-import Tests.Fresh
-import Tests.NonDet
-import Tests.Reader
-import Tests.State
-import Tests.StateRW
+import           Tests.Coroutine
+import           Tests.Exception
+import           Tests.Fresh
+import           Tests.Loop
+import           Tests.NonDet
+import           Tests.Reader
+import           Tests.State
+import           Tests.StateRW
 
 import qualified Data.List
 
@@ -42,7 +43,7 @@ countOddDuoPrefix :: [Int] -> Int
 countOddDuoPrefix list = count list 0
   where
     count (i1:i2:is) n = if even i1 && even i2 then n else count is (n+1)
-    count _ n = n
+    count _ n          = n
 
 coroutineTests :: TestTree
 coroutineTests = testGroup "Coroutine Eff tests"
@@ -88,7 +89,7 @@ primesTo :: Int -> [Int]
 primesTo m = sieve [2..m]       {- (\\) is set-difference for unordered lists -}
   where
     sieve (x:xs) = x : sieve (xs Data.List.\\ [x,x+x..m])
-    sieve [] = []
+    sieve []     = []
 
 nonDetTests :: TestTree
 nonDetTests = testGroup "NonDet tests"
@@ -135,12 +136,14 @@ stateTests = testGroup "State tests"
                              -- Runner --
 --------------------------------------------------------------------------------
 main :: IO ()
-main = defaultMain $ testGroup "Tests"
-  [ pureTests
-  , coroutineTests
-  , exceptionTests
-  , freshTests
-  , nonDetTests
-  , readerTests
-  , stateTests
-  ]
+main = do
+  runForeverLoop
+  defaultMain $ testGroup "Tests"
+    [ pureTests
+    , coroutineTests
+    , exceptionTests
+    , freshTests
+    , nonDetTests
+    , readerTests
+    , stateTests
+    ]

--- a/tests/Tests/Loop.hs
+++ b/tests/Tests/Loop.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Tests.Loop
+  ( runFixLoop
+  , runTailLoop
+  , runForeverLoop
+  ) where
+
+import           Control.Monad       (forever)
+import           Control.Monad.Freer
+import           Data.Function       (fix)
+
+-- | This loops forever as expected
+fixLoop :: Member IO r => Eff r ()
+fixLoop = fix $ \fxLoop -> do
+  send $ putStrLn "fixLoop"
+  fxLoop
+
+runFixLoop :: IO ()
+runFixLoop = runM fixLoop
+
+-- | This loops as expected
+tailLoop :: Member IO r => Eff r ()
+tailLoop = send (putStrLn "tailLoop") >> tailLoop
+
+runTailLoop :: IO ()
+runTailLoop = runM tailLoop
+
+-- | This <<loop>>s.
+foreverLoop ::  Member IO r => Eff r ()
+foreverLoop = forever $ send $ putStrLn "loop"
+
+runForeverLoop :: IO ()
+runForeverLoop = runM foreverLoop

--- a/tests/Tests/Loop.hs
+++ b/tests/Tests/Loop.hs
@@ -7,6 +7,7 @@ module Tests.Loop
   , runForeverLoop
   ) where
 
+import           Control.Concurrent  (forkIO, killThread, threadDelay)
 import           Control.Monad       (forever)
 import           Control.Monad.Freer
 import           Data.Function       (fix)
@@ -32,4 +33,7 @@ foreverLoop ::  Member IO r => Eff r ()
 foreverLoop = forever $ send $ putStrLn "loop"
 
 runForeverLoop :: IO ()
-runForeverLoop = runM foreverLoop
+runForeverLoop = do
+  tid <- forkIO $ runM foreverLoop
+  threadDelay $ 10^6 * 2
+  killThread tid

--- a/tests/hlint.hs
+++ b/tests/hlint.hs
@@ -12,14 +12,14 @@
 module Main (main)
   where
 
-import Control.Monad (unless)
-import Data.Function (($))
-import Data.List (null)
-import Data.Monoid ((<>))
-import System.IO (IO, putStrLn)
-import System.Exit (exitFailure)
+import           Control.Monad          (unless)
+import           Data.Function          (($))
+import           Data.List              (null)
+import           Data.Monoid            ((<>))
+import           System.Exit            (exitFailure)
+import           System.IO              (IO, putStrLn)
 
-import Language.Haskell.HLint (hlint)
+import           Language.Haskell.HLint (hlint)
 
 
 main :: IO ()


### PR DESCRIPTION
It's worth noting I've run into <<loop>> with a number of setups, not just `forever`, but at the time I had suspected it was my own code, and not `freer`. Today I narrowed it down to `freer` (and `freer-effects`) Applicative instance. This fixes that issue and it doesn't look like the benchmarks were affected. Attached is a txt file with before and after benchmarks pasted side by side.

[bench-compare.txt](https://github.com/IxpertaSolutions/freer-effects/files/842768/bench-compare.txt)
