### PR TITLE
Add replaceRelay and friend

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+* Introducing `replaceRelay` and `replaceRelayS`.
+  [PR #27](https://github.com/IxpertaSolutions/freer-effects/pull/27)
+
 ## [0.3.0.0] (March 06, 2017)
 
 * Package renamed to `freer-effects` to distinguish it from original `freer`.

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -61,6 +61,8 @@ module Control.Monad.Freer.Internal
     , handleRelay
     , handleRelayS
     , interpose
+    , replaceRelay
+    , replaceRelayS
 
     -- *** Low-level Functions for Building Effect Handlers
     , qApp
@@ -176,6 +178,42 @@ runM (E u q) = case extract u of
     mb -> mb >>= runM . qApp q
     -- The other case is unreachable since Union [] a cannot be constructed.
     -- Therefore, run is a total function if its argument terminates.
+
+-- | Like 'replaceRelay', but with support for an explicit state to help
+-- implement the interpreter.
+replaceRelayS :: s
+             -> (s -> a -> Eff (v ': effs) w)
+             -> (forall x. s
+                        -> t x
+                        -> (s -> Arr (v ': effs) x w)
+                        -> Eff (v ': effs) w)
+             -> Eff (t ': effs) a
+             -> Eff (v ': effs) w
+replaceRelayS s' pure' bind = loop s'
+ where
+  loop s (Val x)  = pure' s x
+  loop s (E u' q)  = case decomp u' of
+    Right x -> bind s x k
+    Left  u -> E (weaken u) (tsingleton (k s))
+   where k s'' x = loop s'' $ qApp q x
+
+-- | Interpret an effect by transforming it into another effect on top of the
+-- stack. The primary use case of this function is allow interpreters to be
+-- defined in terms of other ones without leaking intermediary implementation
+-- details through the type signature.
+replaceRelay :: (a -> Eff (v ': effs) w)
+             -> (forall x. t x
+                        -> Arr (v ': effs) x w
+                        -> Eff (v ': effs) w)
+             -> Eff (t ': effs) a
+             -> Eff (v ': effs) w
+replaceRelay pure' bind = loop
+ where
+  loop (Val x)  = pure' x
+  loop (E u' q)  = case decomp u' of
+    Right x -> bind x k
+    Left  u -> E (weaken u) (tsingleton k)
+   where k = qComp q loop
 
 -- | Given a request, either handle it or relay it.
 handleRelay

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -181,39 +181,38 @@ runM (E u q) = case extract u of
 
 -- | Like 'replaceRelay', but with support for an explicit state to help
 -- implement the interpreter.
-replaceRelayS :: s
-             -> (s -> a -> Eff (v ': effs) w)
-             -> (forall x. s
-                        -> t x
-                        -> (s -> Arr (v ': effs) x w)
-                        -> Eff (v ': effs) w)
-             -> Eff (t ': effs) a
-             -> Eff (v ': effs) w
+replaceRelayS
+    :: s
+    -> (s -> a -> Eff (v ': effs) w)
+    -> (forall x. s -> t x -> (s -> Arr (v ': effs) x w) -> Eff (v ': effs) w)
+    -> Eff (t ': effs) a
+    -> Eff (v ': effs) w
 replaceRelayS s' pure' bind = loop s'
- where
-  loop s (Val x)  = pure' s x
-  loop s (E u' q)  = case decomp u' of
-    Right x -> bind s x k
-    Left  u -> E (weaken u) (tsingleton (k s))
-   where k s'' x = loop s'' $ qApp q x
+  where
+    loop s (Val x)  = pure' s x
+    loop s (E u' q) = case decomp u' of
+        Right x -> bind s x k
+        Left  u -> E (weaken u) (tsingleton (k s))
+      where
+        k s'' x = loop s'' $ qApp q x
 
 -- | Interpret an effect by transforming it into another effect on top of the
 -- stack. The primary use case of this function is allow interpreters to be
 -- defined in terms of other ones without leaking intermediary implementation
 -- details through the type signature.
-replaceRelay :: (a -> Eff (v ': effs) w)
-             -> (forall x. t x
-                        -> Arr (v ': effs) x w
-                        -> Eff (v ': effs) w)
-             -> Eff (t ': effs) a
-             -> Eff (v ': effs) w
+replaceRelay
+    :: (a -> Eff (v ': effs) w)
+    -> (forall x. t x -> Arr (v ': effs) x w -> Eff (v ': effs) w)
+    -> Eff (t ': effs) a
+    -> Eff (v ': effs) w
 replaceRelay pure' bind = loop
- where
-  loop (Val x)  = pure' x
-  loop (E u' q)  = case decomp u' of
-    Right x -> bind x k
-    Left  u -> E (weaken u) (tsingleton k)
-   where k = qComp q loop
+  where
+    loop (Val x)  = pure' x
+    loop (E u' q) = case decomp u' of
+        Right x -> bind x k
+        Left  u -> E (weaken u) (tsingleton k)
+      where
+        k = qComp q loop
 
 -- | Given a request, either handle it or relay it.
 handleRelay


### PR DESCRIPTION
We've found certain interpreters that want to be implemented in terms of other interpreters; however, if those interpreters themselves have `Member` constraints, they will leak out into the type signature.

`replaceRelay` allows us to rewrite the head of the effects in terms of some other effect which need not exist in the effect list.  This lets us get around the above issue, and provide leakless abstractions for interpreters.