### PR TITLE
Add categorical functors over effects

### DIFF
--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -69,6 +69,7 @@ library
       Control.Monad.Freer.Cut
       Control.Monad.Freer.Exception
       Control.Monad.Freer.Fresh
+      Control.Monad.Freer.Functor
       Control.Monad.Freer.Internal
       Control.Monad.Freer.NonDet
       Control.Monad.Freer.Reader

--- a/src/Control/Monad/Freer/Coroutine.hs
+++ b/src/Control/Monad/Freer/Coroutine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
 -- |
@@ -32,7 +33,9 @@ module Control.Monad.Freer.Coroutine
 import Control.Applicative (pure)
 import Data.Function (($), (.))
 import Data.Functor (Functor)
+import Prelude ((>>=))
 
+import Control.Monad.Freer.Functor (ContraEff (contraeffmap), eff)
 import Control.Monad.Freer.Internal (Eff, Member, handleRelay, interpose, send)
 
 
@@ -50,6 +53,10 @@ import Control.Monad.Freer.Internal (Eff, Member, handleRelay, interpose, send)
 --   The output of the continuation.
 data Yield a b c = Yield a (b -> c)
   deriving (Functor)
+
+instance ContraEff (Yield a) where
+  contraeffmap f = eff $ \arr -> \case
+    Yield a bc -> send (Yield a $ bc . f) >>= arr
 
 -- | Lifts a value and a function into the Coroutine effect.
 yield :: Member (Yield a b) effs => a -> (b -> c) -> Eff effs c

--- a/src/Control/Monad/Freer/Exception.hs
+++ b/src/Control/Monad/Freer/Exception.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
 -- |
@@ -23,10 +24,13 @@ module Control.Monad.Freer.Exception
     )
   where
 
+import Prelude (($), (>>=))
+
 import Control.Applicative (pure)
 import Data.Either (Either(Left, Right))
 import Data.Function ((.))
 
+import Control.Monad.Freer.Functor (CoEff (effmap), eff)
 import Control.Monad.Freer.Internal (Eff, Member, handleRelay, interpose, send)
 
 
@@ -36,6 +40,10 @@ import Control.Monad.Freer.Internal (Eff, Member, handleRelay, interpose, send)
 
 -- | Exceptions of the type @e :: *@ with no resumption.
 newtype Exc e a = Exc e
+
+instance CoEff Exc where
+  effmap f = eff $ \arr -> \case
+    Exc e -> send (Exc $ f e) >>= arr
 
 -- | Throws an error carrying information of type @e :: *@.
 throwError :: Member (Exc e) effs => e -> Eff effs a

--- a/src/Control/Monad/Freer/Functor.hs
+++ b/src/Control/Monad/Freer/Functor.hs
@@ -4,8 +4,9 @@
 
 module Control.Monad.Freer.Functor where
 
+import Control.Applicative (pure)
 import Control.Monad.Freer.Internal (Eff, replaceRelay)
-import Prelude (pure, flip, ($))
+import Prelude (flip, ($))
 
 
 -- | A class witnessing that 'eff' forms a covariant functor in its second type

--- a/src/Control/Monad/Freer/Functor.hs
+++ b/src/Control/Monad/Freer/Functor.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE RankNTypes    #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Control.Monad.Freer.Functor where
+
+import Control.Monad.Freer.Internal (Eff, replaceRelay)
+import Prelude (pure, flip, ($))
+
+
+-- | A class witnessing that 'eff' forms a covariant functor in its second type
+-- parameter.
+class CoEff eff where
+  effmap :: (a -> b) -> Eff (eff a ': effs) x -> Eff (eff b ': effs) x
+
+
+-- | A class witnessing that 'eff' forms a contravariant functor in its second
+-- type parameter.
+class ContraEff eff where
+  contraeffmap :: (b -> a) -> Eff (eff a ': effs) x -> Eff (eff b ': effs) x
+
+
+-- | A class witnessing that 'eff' forms a invariant functor in its second
+-- type parameter.
+class InvEff eff where
+  inveffmap :: (a -> b) -> (b -> a) -> Eff (eff a ': effs) x -> Eff (eff b ': effs) x
+
+
+-- | Helper function for defining 'effmap', 'contraeffmap', and 'inveffmap' by
+-- wrangling 'replaceRelay's type into something that can be type-inferred and
+-- lambda-cased.
+eff :: (forall v. (v -> Eff (eff b ': effs) x) -> eff a v -> Eff (eff b ': effs) x)
+    -> Eff (eff a ': effs) x
+    -> Eff (eff b ': effs) x
+eff f = replaceRelay pure $ flip f
+

--- a/src/Control/Monad/Freer/Reader.hs
+++ b/src/Control/Monad/Freer/Reader.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
@@ -40,7 +41,9 @@ module Control.Monad.Freer.Reader
 
 import Control.Applicative (pure)
 import Data.Functor ((<$>))
+import Prelude (($), (>>=), (.))
 
+import Control.Monad.Freer.Functor (ContraEff (contraeffmap), eff)
 import Control.Monad.Freer.Internal
     ( Arr
     , Eff
@@ -55,6 +58,10 @@ import Control.Monad.Freer.Internal
 -- available to effectful computation.
 data Reader e a where
   Reader :: Reader e e
+
+instance ContraEff Reader where
+  contraeffmap f = eff $ \arr -> \case
+    Reader -> send Reader >>= arr . f
 
 -- | Request a value of the environment.
 ask :: Member (Reader e) effs => Eff effs e

--- a/src/Control/Monad/Freer/State.hs
+++ b/src/Control/Monad/Freer/State.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
@@ -49,7 +50,9 @@ import Data.Functor ((<$>), fmap)
 import Data.Maybe (Maybe(Just))
 import Data.Proxy (Proxy)
 import Data.Tuple (fst, snd)
+import Prelude (($), (.))
 
+import Control.Monad.Freer.Functor (InvEff (inveffmap), eff)
 import Control.Monad.Freer.Internal
     ( Eff(E, Val)
     , Member
@@ -71,6 +74,11 @@ import Control.Monad.Freer.Internal
 data State s a where
     Get :: State s s
     Put :: !s -> State s ()
+
+instance InvEff State where
+  inveffmap f g = eff $ \arr -> \case
+    Get   -> send Get         >>= arr . g
+    Put s -> send (Put $ f s) >>= arr
 
 -- | Retrieve the current value of the state of type @s :: *@.
 get :: Member (State s) effs => Eff effs s

--- a/src/Control/Monad/Freer/Writer.hs
+++ b/src/Control/Monad/Freer/Writer.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
 -- |
@@ -26,16 +27,22 @@ module Control.Monad.Freer.Writer
 
 import Control.Applicative (pure)
 import Control.Arrow (second)
+import Control.Monad ((>>=))
 import Data.Function (($))
 import Data.Functor ((<$>))
 import Data.Monoid (Monoid, (<>), mempty)
 
+import Control.Monad.Freer.Functor (CoEff (effmap), eff)
 import Control.Monad.Freer.Internal (Eff, Member, handleRelay, send)
 
 
 -- | Writer effects - send outputs to an effect environment.
 data Writer w a where
     Writer :: w -> Writer w ()
+
+instance CoEff Writer where
+  effmap f = eff $ \arr -> \case
+    Writer w -> send (Writer $ f w) >>= arr
 
 -- | Send a change to the attached environment.
 tell :: Member (Writer w) effs => w -> Eff effs ()

--- a/tests/Tests/Reader.hs
+++ b/tests/Tests/Reader.hs
@@ -4,7 +4,7 @@
 module Tests.Reader (tests)
   where
 
-import Prelude (Integer, (+), (*), fromIntegral)
+import Prelude (String, Integer, (++), (+), (*), fromIntegral, show)
 
 import Control.Applicative ((<*>), pure)
 import Data.Eq (Eq((==)))
@@ -16,6 +16,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
 import Control.Monad.Freer (run)
+import Control.Monad.Freer.Functor (contraeffmap)
 import Control.Monad.Freer.Reader (ask, local, runReader)
 
 
@@ -27,6 +28,8 @@ tests = testGroup "Reader tests"
         $ \i n -> testMultiReader i n == (i + 2) + fromIntegral (n + 1)
     , testProperty "Local injects into env"
         $ \env inc -> testLocal env inc == 2 * (env + 1) + inc
+    , testProperty "We can effmap Readers: n + x"
+        $ \n x -> testEffmapReader n x == show n ++ show x
     ]
 
 --------------------------------------------------------------------------------
@@ -34,6 +37,9 @@ tests = testGroup "Reader tests"
 --------------------------------------------------------------------------------
 testReader :: Int -> Int -> Int
 testReader n x = run . flip runReader n $ (+) <$> ask <*> pure x
+
+testEffmapReader :: Int -> Int -> String
+testEffmapReader n x = run . flip runReader n . contraeffmap show $ (++) <$> ask <*> pure (show x)
 
 {-
 t1rr' = run t1


### PR DESCRIPTION
This PR represents the work @shlevy and I did during BayHac. It adds typeclasses to represent categorical {co,contra,in}-variant functors for effects, giving us common functions to map over effects.

For example,

```haskell
eg :: Eff '[Writer String] ()
eg = effmap show $ tell True
```

Instances are provided for all effects which have meaningful type parameters.