### PR TITLE
SafeIO effect for catching IO exceptions

### DIFF
--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -73,6 +73,7 @@ library
       Control.Monad.Freer.Internal
       Control.Monad.Freer.NonDet
       Control.Monad.Freer.Reader
+      Control.Monad.Freer.SafeIO
       Control.Monad.Freer.State
       Control.Monad.Freer.StateRW
       Control.Monad.Freer.Trace

--- a/package.yaml
+++ b/package.yaml
@@ -73,6 +73,7 @@ library:
     - Control.Monad.Freer.Internal
     - Control.Monad.Freer.NonDet
     - Control.Monad.Freer.Reader
+    - Control.Monad.Freer.SafeIO
     - Control.Monad.Freer.State
     - Control.Monad.Freer.StateRW
     - Control.Monad.Freer.Trace

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -171,6 +171,10 @@ run _       = error "Internal:run - This (E) should never happen"
 -- | Runs a set of Effects. Requires that all effects are consumed, except for
 -- a single effect known to be a monad. The value returned is a computation in
 -- that monad. This is useful for plugging in traditional transformer stacks.
+--
+-- Note that if the monad is 'IO', you should consider using
+-- 'Control.Monad.Freer.SafeIO.runSafeIO' instead, as it provides the ability
+-- to catch and recover from IO exceptions in 'Eff' code.
 runM :: Monad m => Eff '[m] a -> m a
 runM (Val x) = return x
 runM (E u q) = case extract u of

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -13,7 +13,7 @@ import Control.Monad.Freer (send, Member)
 import Control.Monad.Freer.Internal (qApp, prj, Eff (..))
 import Control.Monad.Freer.Exception (Exc (..), throwError)
 import Control.Exception (throw, SomeException, try)
-
+import Prelude (Maybe (Just), IO, Either (), (>>=), return, (=<<), either, error, (.))
 
 ------------------------------------------------------------------------------
 -- | Safe IO effect.

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Monad.Freer.SafeIO
+  ( SIO ()
+  , runSafeIO
+  , safeIO
+  ) where
+
+import Control.Monad.Freer (send, Member)
+import Control.Monad.Freer.Internal (qApp, prj, Eff (..))
+import Control.Monad.Freer.Exception (Exc (..), throwError)
+import Control.Exception (throw, SomeException, try)
+
+
+------------------------------------------------------------------------------
+-- | Safe IO effect.
+data SIO a where
+  Safely :: IO a -> SIO (Either SomeException a)
+
+
+------------------------------------------------------------------------------
+-- | Interprets 'SIO' into 'IO'. There is an @Exc SomeException@ *underneath*
+-- the safe IO effect here to ensure we always have it in our effect stack. Any
+-- exceptions left unhandled in this effect will be rethrown in IO.
+runSafeIO :: Eff '[SIO, Exc SomeException] w -> IO w
+runSafeIO (Val x) = return x
+runSafeIO (E u q) | Just (Safely m) <- prj u = try m >>= runSafeIO . qApp q
+runSafeIO (E u _) | Just (Exc e)    <- prj u = throw (e :: SomeException)
+runSafeIO (E _ _) = error "can't happen"
+
+
+------------------------------------------------------------------------------
+-- | Lift an 'IO' action to the 'SIO' effect.
+safeIO :: (Member SIO r, Member (Exc SomeException) r) => IO a -> Eff r a
+safeIO io = either throwError return =<< send (Safely io)
+

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -10,8 +10,8 @@ module Control.Monad.Freer.SafeIO
   ) where
 
 import Control.Monad.Freer (send, Member)
-import Control.Monad.Freer.Internal (qApp, prj, Eff (..))
-import Control.Monad.Freer.Exception (Exc (..), throwError)
+import Control.Monad.Freer.Internal (qApp, prj, Eff (E, Val))
+import Control.Monad.Freer.Exception (Exc (Exc), throwError)
 import Control.Exception (throw, SomeException, try)
 import Prelude (Maybe (Just), IO, Either (), (>>=), return, (=<<), either, error, (.))
 


### PR DESCRIPTION
This PR adds a `SafeIO` effect which wraps every `IO` request in `try`, and thus rethrows any synchronous exceptions in the `Exc SomeException` effect. Such a change allows `Eff` code to reason about the presence of `IO` exceptions.

`SafeIO` is a necessary step before we can safely implement `bracket`-esque resource-allocation regions.