### PR TITLE
Add `raise` to weaken an effect stack.

### DIFF
--- a/src/Control/Monad/Freer.hs
+++ b/src/Control/Monad/Freer.hs
@@ -22,6 +22,9 @@ module Control.Monad.Freer
     -- ** Sending Arbitrary Effect
     , send
 
+    -- ** Lifting Effect Stacks
+    , raise
+
     -- * Handling Effects
     , Arr
     , run
@@ -47,6 +50,7 @@ import Control.Monad.Freer.Internal
     , Members
     , handleRelay
     , handleRelayS
+    , raise
     , run
     , runM
     , send

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -53,6 +53,9 @@ module Control.Monad.Freer.Internal
     -- ** Sending Arbitrary Effect
     , send
 
+    -- ** Lifting Effect Stacks
+    , raise
+
     -- * Handling Effects
     , run
     , runM
@@ -267,6 +270,14 @@ interpose ret h = loop
         _      -> E u (tsingleton k)
       where
         k = qComp q loop
+
+-- | Embeds a less-constrained 'Eff' into a more-constrained one. Analogous to
+-- MTL's 'lift'.
+raise :: Eff effs a -> Eff (e ': effs) a
+raise = loop
+  where
+    loop (Val x) = pure x
+    loop (E u q) = E (weaken u) . tsingleton $ qComp q loop
 
 --------------------------------------------------------------------------------
                     -- Nondeterministic Choice --


### PR DESCRIPTION
This PR adds `raise`, which allows you to embed less-specific `Eff` stacks in more-specific ones.