### PR TITLE
Add handler functions for dealing with Writers and Trace interactively

### DIFF
--- a/src/Control/Monad/Freer/Trace.hs
+++ b/src/Control/Monad/Freer/Trace.hs
@@ -24,7 +24,7 @@ module Control.Monad.Freer.Trace
     )
   where
 
-import Control.Monad ((>>), return)
+import Control.Monad ((>>),(>>=), return)
 import Data.Function ((.))
 import Data.String (String)
 import System.IO (IO, putStrLn)
@@ -51,4 +51,4 @@ runTrace (E u q) = case extract u of
 --
 -- > runM . handleTrace putStrLn == runTrace
 handleTrace :: (Member m effs) => (String -> m ()) -> Eff (Trace ': effs) a -> Eff effs a
-handleTrace f = handleRelay return (\(Trace s) k -> send (f s) >> k ())
+handleTrace f = handleRelay return (\(Trace s) k -> send (f s) >>= k)

--- a/src/Control/Monad/Freer/Trace.hs
+++ b/src/Control/Monad/Freer/Trace.hs
@@ -20,6 +20,7 @@ module Control.Monad.Freer.Trace
     ( Trace(..)
     , trace
     , runTrace
+    , handleTrace
     )
   where
 
@@ -28,7 +29,7 @@ import Data.Function ((.))
 import Data.String (String)
 import System.IO (IO, putStrLn)
 
-import Control.Monad.Freer.Internal (Eff(E, Val), Member, extract, qApp, send)
+import Control.Monad.Freer.Internal (Eff(E, Val), Member, extract, qApp, send, handleRelay)
 
 
 -- | A Trace effect; takes a 'String' and performs output.
@@ -44,3 +45,10 @@ runTrace :: Eff '[Trace] a -> IO a
 runTrace (Val x) = return x
 runTrace (E u q) = case extract u of
     Trace s -> putStrLn s >> runTrace (qApp q ())
+
+
+-- | Handle trace messages using another effect, such as IO
+--
+-- > runM . handleTrace putStrLn == runTrace
+handleTrace :: (Member m effs) => (String -> m ()) -> Eff (Trace ': effs) a -> Eff effs a
+handleTrace f = handleRelay return (\(Trace s) k -> send (f s) >> k ())


### PR DESCRIPTION
One of the common uses for `Writer` is to provide pure logging. Sometimes it is useful to be able to get these logging values as they occur during interpretation. I've added functions for interpreting `Writer` and `Trace` in terms of another effect, such as `IO`, allowing `Writer` to be used for logging, using different logging levels and handle each level differently (a use case that has come up at work where we want to add tracing info but ignore it unless debugging).