### PR TITLE
Add Modify constructor to State, and handleState function

### DIFF
--- a/src/Control/Monad/Freer/Trace.hs
+++ b/src/Control/Monad/Freer/Trace.hs
@@ -24,7 +24,7 @@ module Control.Monad.Freer.Trace
     )
   where
 
-import Control.Monad ((>>), return)
+import Control.Monad ((>>),(>>=), return)
 import Data.Function ((.))
 import Data.String (String)
 import System.IO (IO, putStrLn)
@@ -51,4 +51,4 @@ runTrace (E u q) = case extract u of
 --
 -- > runM . handleTrace putStrLn == runTrace
 handleTrace :: (Member m effs) => (String -> m ()) -> Eff (Trace ': effs) a -> Eff effs a
-handleTrace f = handleRelay return (\(Trace s) k -> send (f s) >> k ())
+handleTrace f = handleRelay return (\(Trace s) k -> send (f s) >>= k)

--- a/src/Control/Monad/Freer/Trace.hs
+++ b/src/Control/Monad/Freer/Trace.hs
@@ -20,6 +20,7 @@ module Control.Monad.Freer.Trace
     ( Trace(..)
     , trace
     , runTrace
+    , handleTrace
     )
   where
 
@@ -28,7 +29,7 @@ import Data.Function ((.))
 import Data.String (String)
 import System.IO (IO, putStrLn)
 
-import Control.Monad.Freer.Internal (Eff(E, Val), Member, extract, qApp, send)
+import Control.Monad.Freer.Internal (Eff(E, Val), Member, extract, qApp, send, handleRelay)
 
 
 -- | A Trace effect; takes a 'String' and performs output.
@@ -44,3 +45,10 @@ runTrace :: Eff '[Trace] a -> IO a
 runTrace (Val x) = return x
 runTrace (E u q) = case extract u of
     Trace s -> putStrLn s >> runTrace (qApp q ())
+
+
+-- | Handle trace messages using another effect, such as IO
+--
+-- > runM . handleTrace putStrLn == runTrace
+handleTrace :: (Member m effs) => (String -> m ()) -> Eff (Trace ': effs) a -> Eff effs a
+handleTrace f = handleRelay return (\(Trace s) k -> send (f s) >> k ())


### PR DESCRIPTION
I've separated this from #44 as it's probably more controversial. Adding a `Modify` constructor allows users to know that a modification will be atomic. If you look at the example in the diff, I've shown how this can be used to allow users to run stateful computations on mutable shared state, concurrently with other threads, or isolated in the traditional manner, without modification to the computation.

An alternative implementation would be to implement `Get` and `Put` in terms of `Modify`, but then the example I've provided would end up calling `atomicModifyIORef` many more times than necessary.

Keen to hear feedback on this, I'm not confident that this change is actually worth it, and am sure there are problems I haven't considered.