### PR TITLE
Add custom type errors for unsolvable Member constraints

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,9 @@ All notable changes to this project will be documented in this file.
 * Introduced `raise` to weaken an effect stack.
   [PR #41](https://github.com/IxpertaSolutions/freer-effects/pull/41)
   (**new**)
+* Added support for custom type errors for unsolvable `Member` constraints.
+  [PR #48](https://github.com/IxpertaSolutions/freer-effects/pull/48)
+  (**new**)
 
 ## [0.3.0.1] (April 16, 2017)
 

--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -64,6 +64,8 @@ library
     ghc-options: -Wredundant-constraints -Wmissing-import-lists
   if impl(ghc >=7.10)
     cpp-options: -DDEPRECATED_LANGUAGE_OVERLAPPING_INSTANCES
+  if impl(ghc >=8)
+    cpp-options: -DCUSTOM_TYPE_ERRORS
   exposed-modules:
       Control.Monad.Freer
       Control.Monad.Freer.Coroutine

--- a/package.yaml
+++ b/package.yaml
@@ -84,6 +84,8 @@ library:
   when:
     - condition: impl(ghc >=7.10)
       cpp-options: -DDEPRECATED_LANGUAGE_OVERLAPPING_INSTANCES
+    - condition: impl(ghc >=8)
+      cpp-options: -DCUSTOM_TYPE_ERRORS
 
 executables:
   freer-examples:


### PR DESCRIPTION
This changes `FindElem` to use the new support for custom type errors in GHC 8, so it will provide much better error messages for missing effects. To illustrate, here’s an example that does not compile:

```haskell
foo :: (Member (Reader Integer) effs, Member (State Integer) effs) => Eff effs ()
foo = do
  n :: Integer <- ask
  modify (+ n)

result :: ()
result = run $ runReader foo (0 :: Integer)
```

The definition of `result` is missing a `runState`. Currently, it will produce the following error message:

```
• No instance for (Data.OpenUnion.Internal.FindElem
                     (State Integer) '[])
    arising from a use of ‘foo’
• In the first argument of ‘runReader’, namely ‘foo’
  In the second argument of ‘($)’, namely
    ‘runReader foo (0 :: Integer)’
  In the expression: run $ runReader foo (0 :: Integer)
```

…which is a little bit cryptic, and also lets the implementation details of `OpenUnion` leak into the error message. With these changes, the error changes to this:

```
• ‘State Integer’ is not a member of the type-level list
    ‘'[Reader Integer]’
  In the constraint (Member (State Integer) '[Reader Integer])
• In the first argument of ‘runReader’, namely ‘foo’
  In the second argument of ‘($)’, namely
    ‘runReader foo (0 :: Integer)’
  In the expression: run $ runReader foo (0 :: Integer)
```

It does this by adding an extra type to the `FindElem` class, which tracks the “original” list for error reporting purposes.