### PR TITLE
Add Safe Haskell pragmas

### DIFF
--- a/src/Control/Monad/Freer.hs
+++ b/src/Control/Monad/Freer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer
 -- Description:  Freer - an extensible effects library

--- a/src/Control/Monad/Freer/Coroutine.hs
+++ b/src/Control/Monad/Freer/Coroutine.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.Coroutine
 -- Description:  Composable coroutine effects layer.

--- a/src/Control/Monad/Freer/Cut.hs
+++ b/src/Control/Monad/Freer/Cut.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.Cut
 -- Description:  An implementation of logical Cut.

--- a/src/Control/Monad/Freer/Exception.hs
+++ b/src/Control/Monad/Freer/Exception.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.Exception
 -- Description:  An Exception effect and handler.

--- a/src/Control/Monad/Freer/Fresh.hs
+++ b/src/Control/Monad/Freer/Fresh.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 
 -- |
 -- Module:       Control.Monad.Freer.Fresh

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 
 -- The following is needed to define MonadPlus instance. It is decidable
 -- (there is no recursion!), but GHC cannot see that.

--- a/src/Control/Monad/Freer/NonDet.hs
+++ b/src/Control/Monad/Freer/NonDet.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.NonDet
 -- Description:  Non deterministic effects

--- a/src/Control/Monad/Freer/Reader.hs
+++ b/src/Control/Monad/Freer/Reader.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.Reader
 -- Description:  Reader effects, for encapsulating an environment.

--- a/src/Control/Monad/Freer/State.hs
+++ b/src/Control/Monad/Freer/State.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.State
 -- Description:  State effects, for state-carrying computations.

--- a/src/Control/Monad/Freer/StateRW.hs
+++ b/src/Control/Monad/Freer/StateRW.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.StateRW
 -- Description:  State effects in terms of Reader and Writer.

--- a/src/Control/Monad/Freer/Trace.hs
+++ b/src/Control/Monad/Freer/Trace.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.Trace
 -- Description:  Composable Trace effects.

--- a/src/Control/Monad/Freer/Writer.hs
+++ b/src/Control/Monad/Freer/Writer.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Control.Monad.Freer.Writer
 -- Description:  Composable Writer effects.

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module:       Data.FTCQueue
 -- Description:  Fast type-aligned queue optimized to effectful functions.

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE Trustworthy #-}
 -- |
 -- Module:       Data.OpenUnion
 -- Description:  Open unions (type-indexed co-products) for extensible effects.


### PR DESCRIPTION
* `Data.OpenUnion` needs to be marked as trustworthy so it can import `Data.OpenUnion.Internal`. 
* `Data.OpenUnion.Internal` does not enforce type-safety due to the ability to perform an arbitrary unsafeCoerce, so it would be incorrect to mark it as trustworthy - so it gets no annotations.
* All other modules can then be inferred safe - Safe pragma added to ensure this remains the case.